### PR TITLE
add protobuf content types for protobufParser

### DIFF
--- a/lib/koa-protobuf.js
+++ b/lib/koa-protobuf.js
@@ -1,6 +1,7 @@
 const parse = require('co-body');
 const contentType = require('content-type');
 const getRawBody = require('raw-body');
+const protobufContentTypes = ['application/x-protobuf', 'application/protobuf', 'application/vnd.google.protobuf'];
 
 /**
  * Parse a protobuf message sent by a client.
@@ -23,7 +24,7 @@ module.exports.protobufParser = function (messageType, options = {}) {
     let type = contentType.parse(ctx).type;
     let success;
 
-    if (type === 'application/x-protobuf') {
+    if (protobufContentTypes.indexOf(type) > -1) {
       success = await _parseProtobuf(ctx, messageType);
     } else if (type === 'application/json' && options.parseJson !== false) {
       success = await _parseJson(ctx, messageType);


### PR DESCRIPTION
See https://stackoverflow.com/questions/30505408/what-is-the-correct-protobuf-content-type
Protobuf has three common content types: 'application/x-protobuf', 'application/protobuf', 'application/vnd.google.protobuf'